### PR TITLE
Tailor pre-commit for md files

### DIFF
--- a/dsproject/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/dsproject/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     hooks:
     - id: trailing-whitespace
     - id: check-added-large-files
+      exclude: \.md
     - id: check-ast
     - id: check-json
     - id: check-merge-conflict

--- a/pyproject/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/pyproject/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: v2.2.3
     hooks:
     - id: trailing-whitespace
+      exclude: \.md
     - id: check-added-large-files
     - id: check-ast
     - id: check-json


### PR DESCRIPTION
Exclude markdown files from the
trim-trailing-whiltespace pre-commit hook.

Fixes #26.